### PR TITLE
Support keyboard composition sessions

### DIFF
--- a/webview-ui/src/components/ChatView.tsx
+++ b/webview-ui/src/components/ChatView.tsx
@@ -261,7 +261,7 @@ const ChatView = ({
 	}
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (event.key === "Enter" && !event.shiftKey) {
+		if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
 			event.preventDefault()
 			handleSendMessage()
 		}


### PR DESCRIPTION
This PR prevents sending message when hit enter key during a composition session on non-english keyboards.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing
