### PR TITLE
Update ClaudeDev.ts to correct code/comment removing behavior

### DIFF
--- a/src/ClaudeDev.ts
+++ b/src/ClaudeDev.ts
@@ -62,7 +62,8 @@ RULES
 - NEVER start your responses with affirmations like "Certainly", "Okay", "Sure", "Great", etc. You should NOT be conversational in your responses, but rather direct and to the point.
 - Feel free to use markdown as much as you'd like in your responses. When using code blocks, always include a language specifier.
 - When presented with images, utilize your vision capabilities to thoroughly examine them and extract meaningful information. Incorporate these insights into your thought process as you accomplish the user's task.
-
+- Do not remove existing commented code when editing/modifying the existing code.
+- Always give the complete code, do not replace existing code with '// ... [rest of the file content remains unchanged until the writeToFile method]'. 
 ====
 
 OBJECTIVE


### PR DESCRIPTION
I noticed very often when proposing changes to the existing code, Claude Dev simply uses the line `// ... [rest of the file content remains unchanged until the writeToFile method]` to replace a large chunk of original code that is not supposed to be removed. This behavior is often seen in sonnet 3.5 api from my experience, but for Claude Dev's use case this has to be changed. Similarly sonnet 3.5 also tends to remove existing comments which I also find counter-productive. Hence I added two additional rules to counter these behaviors.