### PR TITLE
Add AWS Session Token support for Bedrock API 

### DIFF
--- a/src/api/bedrock.ts
+++ b/src/api/bedrock.ts
@@ -12,9 +12,10 @@ export class AwsBedrockHandler implements ApiHandler {
 		this.options = options
 		this.client = new AnthropicBedrock({
 			// Authenticate by either providing the keys below or use the default AWS credential providers, such as
-			// using ~/.aws/credentials or the "AWS_SECRET_ACCESS_KEY" and "AWS_ACCESS_KEY_ID" environment variables.
+			// using ~/.aws/credentials or the "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", and "AWS_SESSION_TOKEN" environment variables.
 			awsAccessKey: this.options.awsAccessKey,
 			awsSecretKey: this.options.awsSecretKey,
+			awsSessionToken: this.options.awsSessionToken,
 
 			// awsRegion changes the aws region to which the request is made. By default, we read AWS_REGION,
 			// and if that's not present, we default to us-east-1. Note that we do not read ~/.aws/config for the region.

--- a/src/providers/ClaudeDevProvider.ts
+++ b/src/providers/ClaudeDevProvider.ts
@@ -310,6 +310,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 								openRouterApiKey,
 								awsAccessKey,
 								awsSecretKey,
+								awsSessionToken,
 								awsRegion,
 							} = message.apiConfiguration
 							await this.updateGlobalState("apiProvider", apiProvider)
@@ -318,6 +319,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("openRouterApiKey", openRouterApiKey)
 							await this.storeSecret("awsAccessKey", awsAccessKey)
 							await this.storeSecret("awsSecretKey", awsSecretKey)
+							await this.storeSecret("awsSessionToken", awsSessionToken)
 							await this.updateGlobalState("awsRegion", awsRegion)
 							this.claudeDev?.updateApi(message.apiConfiguration)
 						}

--- a/src/providers/ClaudeDevProvider.ts
+++ b/src/providers/ClaudeDevProvider.ts
@@ -15,7 +15,7 @@ https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default
 https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
 */
 
-type SecretKey = "apiKey" | "openRouterApiKey" | "awsAccessKey" | "awsSecretKey"
+type SecretKey = "apiKey" | "openRouterApiKey" | "awsAccessKey" | "awsSecretKey" | "awsSessionToken"
 type GlobalStateKey =
 	| "apiProvider"
 	| "apiModelId"
@@ -597,6 +597,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 			openRouterApiKey,
 			awsAccessKey,
 			awsSecretKey,
+			awsSessionToken,
 			awsRegion,
 			maxRequestsPerTask,
 			lastShownAnnouncementId,
@@ -610,6 +611,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 			this.getSecret("openRouterApiKey") as Promise<string | undefined>,
 			this.getSecret("awsAccessKey") as Promise<string | undefined>,
 			this.getSecret("awsSecretKey") as Promise<string | undefined>,
+			this.getSecret("awsSessionToken") as Promise<string | undefined>,
 			this.getGlobalState("awsRegion") as Promise<string | undefined>,
 			this.getGlobalState("maxRequestsPerTask") as Promise<number | undefined>,
 			this.getGlobalState("lastShownAnnouncementId") as Promise<string | undefined>,
@@ -640,6 +642,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 				openRouterApiKey,
 				awsAccessKey,
 				awsSecretKey,
+				awsSessionToken,
 				awsRegion,
 			},
 			maxRequestsPerTask,
@@ -713,7 +716,7 @@ export class ClaudeDevProvider implements vscode.WebviewViewProvider {
 		for (const key of this.context.globalState.keys()) {
 			await this.context.globalState.update(key, undefined)
 		}
-		const secretKeys: SecretKey[] = ["apiKey", "openRouterApiKey", "awsAccessKey", "awsSecretKey"]
+		const secretKeys: SecretKey[] = ["apiKey", "openRouterApiKey", "awsAccessKey", "awsSecretKey", "awsSessionToken"]
 		for (const key of secretKeys) {
 			await this.storeSecret(key, undefined)
 		}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -6,6 +6,7 @@ export interface ApiHandlerOptions {
 	openRouterApiKey?: string
 	awsAccessKey?: string
 	awsSecretKey?: string
+	awsSessionToken?: string
 	awsRegion?: string
 }
 

--- a/webview-ui/src/components/ApiOptions.tsx
+++ b/webview-ui/src/components/ApiOptions.tsx
@@ -139,6 +139,13 @@ const ApiOptions: React.FC<ApiOptionsProps> = ({ showModelOptions, apiErrorMessa
 						placeholder="Enter Secret Key...">
 						<span style={{ fontWeight: 500 }}>AWS Secret Key</span>
 					</VSCodeTextField>
+					<VSCodeTextField
+						value={apiConfiguration?.awsSessionToken || ""}
+						style={{ width: "100%" }}
+						onInput={handleInputChange("awsSessionToken")}
+						placeholder="Enter Session Token (optional)...">
+						<span style={{ fontWeight: 500 }}>AWS Session Token</span>
+					</VSCodeTextField>
 					<div className="dropdown-container">
 						<label htmlFor="aws-region-dropdown">
 							<span style={{ fontWeight: 500 }}>AWS Region</span>


### PR DESCRIPTION
Resolves #88

This pull request adds support for the AWS Session Token when using the Bedrock API. This value is needed when using temporary AWS credentials.


I was able to test locally with my aws credentials
![Screenshot 2024-08-28 at 12 15 28 AM](https://github.com/user-attachments/assets/9d161e2e-f635-419a-af5f-dbcc1a3c3c03)

---
Fun fact, I made this PR with aider:

> I use dynamic aws credentials, that requires AWS_SESSION_TOKEN in addition to the key id and secret access key. Can we adjust the `ApiHandlerOptions` type and the bedrock client creation to include this?

Tokens: 5.8k sent, 657 received. Cost: $0.03 message, $0.03 session.

> Let's add the concept to ApiOptions and ClaudeDevProvider too

Tokens: 16k sent, 1.3k received. Cost: $0.07 message, $0.10 session.

> did we miss anything? onDidReceiveMessage?

Tokens: 16k sent, 538 received. Cost: $0.06 message, $0.15 session.


