### PR TITLE
docs: add bug_report and feature_request templates for new GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Claude-Dev VSCode Details:**
+ - OS: [e.g. iOS]
+ - Model Interface: Anthropic / Openrouter / Ollama / etc
+ - VSCode: Insiders, Stable, Cursor / Fork
+ - IDE Version: Version [e.g. 22]
+ - Remote (WSL, SSH, Codespaces, etc) or Local?
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This should stop the really annoying non-informational bug reports and feature requests, it urges users to be more detailed so we can triage things better.

Make sure there aren't anything I missed here in this area of the bug_report.md template

```
**Claude-Dev VSCode Details:**
 - OS: [e.g. iOS]
 - Model Interface: Anthropic / Openrouter / Ollama / etc
 - VSCode: Insiders, Stable, Cursor / Fork
 - IDE Version: Version [e.g. 22]
 - Remote (WSL, SSH, Codespaces, etc) or Local?
```