### PR TITLE
[Feature Request #278] adding timestamp to the exported Task markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build Claude Dev locally, follow these steps:
     ```bash
     npm run install:all
     ```
-4. Launch by pressing `F5` to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
+4. Launch by pressing `F5` (or `Run`->`Start Debugging`) to open a new VSCode window with the extension loaded. (You may need to install the [esbuild problem matchers extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers) if you run into issues building the project.)
 
 ## Reviews
 

--- a/src/utils/export-markdown.ts
+++ b/src/utils/export-markdown.ts
@@ -7,6 +7,7 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 	// File name
 	const date = new Date(dateTs)
 	const month = date.toLocaleString("en-US", { month: "short" }).toLowerCase()
+	const monthLong = date.toLocaleString("en-US", { month: "long" })
 	const day = date.getDate()
 	const year = date.getFullYear()
 	let hours = date.getHours()
@@ -24,8 +25,8 @@ export async function downloadTask(dateTs: number, conversationHistory: Anthropi
 			const content = Array.isArray(message.content)
 				? message.content.map(formatContentBlockToMarkdown).join("\n")
 				: message.content
-
-			return `${role}\n\n${content}\n\n`
+			const timestamp = `# ${monthLong} ${day},${year} ${hours}:${minutes}:${seconds}${ampm}`;
+			return `${timestamp}\n${role}\n\n${content}\n\n`
 		})
 		.join("---\n\n")
 


### PR DESCRIPTION
per feature request https://github.com/saoudrizwan/claude-dev/issues/278 
this makes the file more readable/parseable.

also added minor fix in README for debugging.

Test Plan:
1. Launch Debug Instance of VSCode
2. Went to extension window, clicked on a recent Task, clicked "Export"
3. Opened saved export file, saw properly formatted timestamp above each User/Assistant action.

<img width="508" alt="Screenshot 2024-09-13 at 9 09 10 AM" src="https://github.com/user-attachments/assets/24b7620f-ccc6-4adf-bcb2-4e29896424ca">
