### PR TITLE
[small bug] incorrect url for Anthropic keys

### DIFF
--- a/webview-ui/src/components/ApiOptions.tsx
+++ b/webview-ui/src/components/ApiOptions.tsx
@@ -168,7 +168,7 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage }: ApiOptionsProps) => {
 						This key is stored locally and only used to make API requests from this extension.
 						{!apiConfiguration?.apiKey && (
 							<VSCodeLink
-								href="https://console.anthropic.com/"
+								href="https://console.anthropic.com/settings/keys"
 								style={{ display: "inline", fontSize: "inherit" }}>
 								You can get an Anthropic API key by signing up here.
 							</VSCodeLink>


### PR DESCRIPTION
hard-linking to the exact console page for creating an Anthropic key, instead of just the main console.

current page:
<img width="779" alt="Screenshot 2024-09-13 at 6 44 04 PM" src="https://github.com/user-attachments/assets/a880fc8c-1fe9-491d-ab06-76995f1229f0">

"correct" page:
<img width="573" alt="Screenshot 2024-09-13 at 6 42 53 PM" src="https://github.com/user-attachments/assets/d4895e34-251e-44fb-8d30-b0e940c88075">

Test Plan:
1. opened Claude Dev console
2. hit Settings button
3. choose API Provider -> Anthropic
4. Clicked on "You can get an Anthropic key by signing in here."
5. Verified that it went directly to Anthropic API keys page

